### PR TITLE
Fix(BossHP): LogMessage instead of LogError

### DIFF
--- a/addons/sourcemod/scripting/BossHP.sp
+++ b/addons/sourcemod/scripting/BossHP.sp
@@ -207,7 +207,7 @@ stock void LoadOldConfig()
 		return;
 	}
 	if (g_cvVerboseLog.IntValue > 0)
-		LogMessage("Found mapconfig: \"%s\"", sConfigFile);
+		LogError("Found mapconfig: \"%s\"", sConfigFile);
 
 	KeyValues KvConfig = new KeyValues("bosses");
 	if(!KvConfig.ImportFromFile(sConfigFile))

--- a/addons/sourcemod/scripting/BossHP.sp
+++ b/addons/sourcemod/scripting/BossHP.sp
@@ -201,7 +201,7 @@ stock void LoadOldConfig()
 
 	char sConfigFile[PLATFORM_MAX_PATH];
 	BuildPath(Path_SM, sConfigFile, sizeof(sConfigFile), "configs/bosshp/%s.cfg", sMapName);
-	if(!FileExists(sConfigFile))
+	if(!FileExists(sConfigFile) && g_cvVerboseLog.IntValue > 0)
 	{
 		LogMessage("Could not find mapconfig: \"%s\"", sConfigFile);
 		return;

--- a/addons/sourcemod/scripting/BossHP.sp
+++ b/addons/sourcemod/scripting/BossHP.sp
@@ -203,7 +203,7 @@ stock void LoadOldConfig()
 	BuildPath(Path_SM, sConfigFile, sizeof(sConfigFile), "configs/bosshp/%s.cfg", sMapName);
 	if(!FileExists(sConfigFile))
 	{
-		LogError("Could not find mapconfig: \"%s\"", sConfigFile);
+		LogMessage("Could not find mapconfig: \"%s\"", sConfigFile);
 		return;
 	}
 	if (g_cvVerboseLog.IntValue > 0)


### PR DESCRIPTION
Prevent useless error in logs.
Exemple : 
![image](https://user-images.githubusercontent.com/11679883/185003387-e35bc5aa-b3d5-4992-b228-3c0bbf1c3689.png)
